### PR TITLE
ci: linter fixes

### DIFF
--- a/tests/Example/ExampleCodeQualityTest.php
+++ b/tests/Example/ExampleCodeQualityTest.php
@@ -6,36 +6,36 @@ describe('Example Application Code Quality', function (): void {
 
     it('has proper PHP declarations in controllers', function () use ($examplePath): void {
         $controllers = glob($examplePath . '/app/Http/Controllers/**/*.php');
-        
+
         foreach ($controllers as $controller) {
             $content = file_get_contents($controller);
             $filename = basename($controller);
-            
+
             expect($content)
                 ->toContain('<?php')
                 ->toContain('declare(strict_types=1);')
                 ->toContain('namespace App\Http\Controllers')
                 ->unless(
                     str_contains($controller, '/Admin/'),
-                    fn($e) => $e->toContain('namespace App\Http\Controllers;'),
-                    fn($e) => $e->toContain('namespace App\Http\Controllers\Admin;')
+                    fn ($e) => $e->toContain('namespace App\Http\Controllers;'),
+                    fn ($e) => $e->toContain('namespace App\Http\Controllers\Admin;'),
                 );
         }
     });
 
     it('has proper PHP declarations in models', function () use ($examplePath): void {
         $models = glob($examplePath . '/app/Models/*.php');
-        
+
         foreach ($models as $model) {
             $content = file_get_contents($model);
             $filename = basename($model);
-            
+
             expect($content)
                 ->toContain('<?php')
                 ->toContain('namespace App\Models;');
-            
+
             // User model extends Authenticatable, others extend Model
-            if ($filename !== 'User.php') {
+            if ('User.php' !== $filename) {
                 expect($content)->toContain('use Illuminate\Database\Eloquent\Model;');
             } else {
                 expect($content)->toContain('use Illuminate\Foundation\Auth\User as Authenticatable;');
@@ -45,10 +45,10 @@ describe('Example Application Code Quality', function (): void {
 
     it('has proper PHP declarations in requests', function () use ($examplePath): void {
         $requests = glob($examplePath . '/app/Http/Requests/*.php');
-        
+
         foreach ($requests as $request) {
             $content = file_get_contents($request);
-            
+
             expect($content)
                 ->toContain('<?php')
                 ->toContain('declare(strict_types=1);')
@@ -63,10 +63,10 @@ describe('Example Application Code Quality', function (): void {
             $examplePath . '/app/Http/Controllers/TeamController.php',
             $examplePath . '/app/Http/Controllers/FolderController.php',
         ];
-        
+
         foreach ($controllers as $controller) {
             $content = file_get_contents($controller);
-            
+
             expect($content)
                 ->toContain('): View')
                 ->toContain('): RedirectResponse')
@@ -77,10 +77,10 @@ describe('Example Application Code Quality', function (): void {
 
     it('migrations follow Laravel naming conventions', function () use ($examplePath): void {
         $migrations = glob($examplePath . '/database/migrations/*.php');
-        
+
         foreach ($migrations as $migration) {
             $filename = basename($migration);
-            
+
             expect($filename)
                 ->toMatch('/^\d{4}_\d{2}_\d{2}_\d{6}_\w+\.php$/');
         }
@@ -88,7 +88,7 @@ describe('Example Application Code Quality', function (): void {
 
     it('routes file uses proper middleware syntax', function () use ($examplePath): void {
         $routesContent = file_get_contents($examplePath . '/routes/web.php');
-        
+
         expect($routesContent)
             ->toContain("Route::middleware(['auth'])")
             ->toContain("Route::middleware(['openfga:")
@@ -99,7 +99,7 @@ describe('Example Application Code Quality', function (): void {
 
     it('docker-compose.yml has valid structure', function () use ($examplePath): void {
         $dockerCompose = file_get_contents($examplePath . '/docker-compose.yml');
-        
+
         expect($dockerCompose)
             ->toContain("version: '3.8'")
             ->toContain('services:')
@@ -116,7 +116,7 @@ describe('Example Application Code Quality', function (): void {
     it('OpenFGA model.json has valid structure', function () use ($examplePath): void {
         $modelJson = file_get_contents($examplePath . '/openfga/model.json');
         $model = json_decode($modelJson, true);
-        
+
         expect($model)
             ->toBeArray()
             ->toHaveKey('schema_version', '1.1')
@@ -124,22 +124,22 @@ describe('Example Application Code Quality', function (): void {
             ->and($model['type_definitions'])
             ->toBeArray()
             ->toHaveCount(6);
-        
-        $types = array_map(fn($def) => $def['type'], $model['type_definitions']);
-        
+
+        $types = array_map(fn ($def) => $def['type'], $model['type_definitions']);
+
         expect($types)->toBe([
             'user',
-            'organization', 
+            'organization',
             'department',
             'team',
             'folder',
-            'document'
+            'document',
         ]);
     });
 
     it('README.md has comprehensive documentation', function () use ($examplePath): void {
         $readme = file_get_contents($examplePath . '/README.md');
-        
+
         expect($readme)
             ->toContain('OpenFGA Laravel Example Application')
             ->toContain('## Overview')
@@ -155,7 +155,7 @@ describe('Example Application Code Quality', function (): void {
 
     it('install.sh has proper error handling', function () use ($examplePath): void {
         $installScript = file_get_contents($examplePath . '/install.sh');
-        
+
         expect($installScript)
             ->toContain('set -e')
             ->toContain('#!/bin/bash')
@@ -168,7 +168,7 @@ describe('Example Application Code Quality', function (): void {
 
     it('docker-setup.sh has proper structure', function () use ($examplePath): void {
         $dockerSetup = file_get_contents($examplePath . '/docker-setup.sh');
-        
+
         expect($dockerSetup)
             ->toContain('#!/bin/bash')
             ->toContain('set -e')

--- a/tests/Example/ExampleControllerTest.php
+++ b/tests/Example/ExampleControllerTest.php
@@ -6,7 +6,7 @@ describe('Example Application Controllers', function (): void {
 
     it('DocumentController has all required methods', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/DocumentController.php');
-        
+
         expect($content)
             ->toContain('public function index(')
             ->toContain('public function create(')
@@ -26,7 +26,7 @@ describe('Example Application Controllers', function (): void {
 
     it('OrganizationController has proper CRUD methods', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/OrganizationController.php');
-        
+
         expect($content)
             ->toContain('public function index(): View')
             ->toContain('public function show(Organization $organization): View')
@@ -43,7 +43,7 @@ describe('Example Application Controllers', function (): void {
 
     it('TeamController has member management methods', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/TeamController.php');
-        
+
         expect($content)
             ->toContain('public function index(): View')
             ->toContain('public function show(Team $team): View')
@@ -54,7 +54,7 @@ describe('Example Application Controllers', function (): void {
 
     it('FolderController handles hierarchical operations', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/FolderController.php');
-        
+
         expect($content)
             ->toContain('public function index(): View')
             ->toContain('public function show(Folder $folder): View')
@@ -68,7 +68,7 @@ describe('Example Application Controllers', function (): void {
 
     it('Admin UserController has permission checking', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/Admin/UserController.php');
-        
+
         expect($content)
             ->toContain('namespace App\Http\Controllers\Admin;')
             ->toContain('public function index(): View')
@@ -81,7 +81,7 @@ describe('Example Application Controllers', function (): void {
 
     it('Admin AuditController handles audit logs', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Controllers/Admin/AuditController.php');
-        
+
         expect($content)
             ->toContain('namespace App\Http\Controllers\Admin;')
             ->toContain('public function index(Request $request): View')
@@ -92,13 +92,13 @@ describe('Example Application Controllers', function (): void {
 
     it('controllers use authorization correctly', function () use ($examplePath): void {
         $documentController = file_get_contents($examplePath . '/app/Http/Controllers/DocumentController.php');
-        
+
         expect($documentController)
             ->toContain('OpenFga::batchCheck(')
             ->toContain('->check(')
             ->toContain('whereUserCan(')
             ->toContain('batchCheckDocumentPermissions(');
-        
+
         // Check that models use grant/revoke
         $documentModel = file_get_contents($examplePath . '/app/Models/Document.php');
         expect($documentModel)
@@ -108,7 +108,7 @@ describe('Example Application Controllers', function (): void {
 
     it('controllers validate input properly', function () use ($examplePath): void {
         $organizationController = file_get_contents($examplePath . '/app/Http/Controllers/OrganizationController.php');
-        
+
         expect($organizationController)
             ->toContain('$request->validate([')
             ->toContain("'name' => 'required|string|max:255'")

--- a/tests/Example/ExampleIntegrationTest.php
+++ b/tests/Example/ExampleIntegrationTest.php
@@ -6,14 +6,14 @@ describe('Example Application Integration', function (): void {
 
     it('routes file integrates with all controllers', function () use ($examplePath): void {
         $routesContent = file_get_contents($examplePath . '/routes/web.php');
-        
+
         // Check controller imports
         expect($routesContent)
             ->toContain('use App\Http\Controllers\DocumentController;')
             ->toContain('use App\Http\Controllers\OrganizationController;')
             ->toContain('use App\Http\Controllers\TeamController;')
             ->toContain('use App\Http\Controllers\FolderController;');
-        
+
         // Check document routes
         expect($routesContent)
             ->toContain('[DocumentController::class, \'index\']')
@@ -23,21 +23,21 @@ describe('Example Application Integration', function (): void {
             ->toContain('[DocumentController::class, \'edit\']')
             ->toContain('[DocumentController::class, \'update\']')
             ->toContain('[DocumentController::class, \'destroy\']');
-        
+
         // Check organization routes
         expect($routesContent)
             ->toContain('[OrganizationController::class, \'index\']')
             ->toContain('[OrganizationController::class, \'show\']')
             ->toContain('[OrganizationController::class, \'members\']')
             ->toContain('[OrganizationController::class, \'createDepartment\']');
-        
+
         // Check team routes
         expect($routesContent)
             ->toContain('[TeamController::class, \'index\']')
             ->toContain('[TeamController::class, \'show\']')
             ->toContain('[TeamController::class, \'documents\']')
             ->toContain('[TeamController::class, \'addMember\']');
-        
+
         // Check folder routes
         expect($routesContent)
             ->toContain('[FolderController::class, \'index\']')
@@ -48,30 +48,30 @@ describe('Example Application Integration', function (): void {
 
     it('routes use OpenFGA middleware correctly', function () use ($examplePath): void {
         $routesContent = file_get_contents($examplePath . '/routes/web.php');
-        
+
         // Document permissions
         expect($routesContent)
             ->toContain("middleware(['openfga:viewer,document:{document}'])")
             ->toContain("middleware(['openfga:editor,document:{document}'])")
             ->toContain("middleware(['openfga:owner,document:{document}'])");
-        
+
         // Organization permissions
         expect($routesContent)
             ->toContain("middleware(['openfga:member,organization:{organization}'])")
             ->toContain("middleware(['openfga:manager,organization:{organization}'])")
             ->toContain("middleware(['openfga:admin,organization:{organization}'])");
-        
+
         // Team permissions
         expect($routesContent)
             ->toContain("middleware(['openfga:member,team:{team}'])")
             ->toContain("middleware(['openfga:lead,team:{team}'])");
-        
+
         // Folder permissions
         expect($routesContent)
             ->toContain("middleware(['openfga:viewer,folder:{folder}'])")
             ->toContain("middleware(['openfga:editor,folder:{folder}'])")
             ->toContain("middleware(['openfga:admin,folder:{folder}'])");
-        
+
         // Advanced middleware patterns
         expect($routesContent)
             ->toContain("middleware(['openfga.any:admin|manager,organization:{organization}'])")
@@ -80,7 +80,7 @@ describe('Example Application Integration', function (): void {
 
     it('admin routes use proper namespace', function () use ($examplePath): void {
         $routesContent = file_get_contents($examplePath . '/routes/web.php');
-        
+
         expect($routesContent)
             ->toContain("Route::prefix('admin')->name('admin.')")
             ->toContain("middleware(['auth', 'openfga:admin,system:global'])")
@@ -90,7 +90,7 @@ describe('Example Application Integration', function (): void {
 
     it('API endpoints are properly defined', function () use ($examplePath): void {
         $routesContent = file_get_contents($examplePath . '/routes/web.php');
-        
+
         expect($routesContent)
             ->toContain("Route::prefix('api')->name('api.')")
             ->toContain("Route::post('/permissions/check'")
@@ -101,7 +101,7 @@ describe('Example Application Integration', function (): void {
 
     it('models integrate with seeders properly', function () use ($examplePath): void {
         $seederContent = file_get_contents($examplePath . '/database/seeders/ExampleSeeder.php');
-        
+
         expect($seederContent)
             ->toContain('use App\Models\Department;')
             ->toContain('use App\Models\Document;')
@@ -118,7 +118,7 @@ describe('Example Application Integration', function (): void {
 
     it('feature test uses SDK correctly', function () use ($examplePath): void {
         $testContent = file_get_contents($examplePath . '/tests/Feature/DocumentManagementTest.php');
-        
+
         expect($testContent)
             ->toContain('use OpenFGA\Laravel\Testing\{FakesOpenFga')
             ->toContain('use RefreshDatabase, FakesOpenFga')
@@ -131,7 +131,7 @@ describe('Example Application Integration', function (): void {
 
     it('Docker setup integrates all services', function () use ($examplePath): void {
         $dockerSetup = file_get_contents($examplePath . '/docker-setup.sh');
-        
+
         expect($dockerSetup)
             ->toContain('docker compose up -d')
             ->toContain('docker compose exec -T app php artisan key:generate')
@@ -145,7 +145,7 @@ describe('Example Application Integration', function (): void {
 
     it('install script integrates package correctly', function () use ($examplePath): void {
         $installScript = file_get_contents($examplePath . '/install.sh');
-        
+
         expect($installScript)
             ->toContain('composer require evansims/openfga-laravel')
             ->toContain('php artisan vendor:publish --provider="OpenFGA\Laravel\OpenFgaServiceProvider"')

--- a/tests/Example/ExampleMigrationTest.php
+++ b/tests/Example/ExampleMigrationTest.php
@@ -6,7 +6,7 @@ describe('Example Application Migrations', function (): void {
 
     it('organizations migration has correct structure', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000001_create_organizations_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('organizations'")
             ->toContain('$table->id();')
@@ -17,7 +17,7 @@ describe('Example Application Migrations', function (): void {
             ->toContain('$table->timestamps();')
             ->toContain("\$table->index('slug');")
             ->toContain("\$table->index('created_at');");
-        
+
         // Check pivot table
         expect($content)
             ->toContain("Schema::create('organization_user'")
@@ -29,7 +29,7 @@ describe('Example Application Migrations', function (): void {
 
     it('departments migration has organization relationship', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000002_create_departments_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('departments'")
             ->toContain("\$table->foreignId('organization_id')->constrained()->cascadeOnDelete();")
@@ -40,7 +40,7 @@ describe('Example Application Migrations', function (): void {
 
     it('teams migration has department relationship', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000003_create_teams_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('teams'")
             ->toContain("\$table->foreignId('department_id')->constrained()->cascadeOnDelete();")
@@ -50,7 +50,7 @@ describe('Example Application Migrations', function (): void {
 
     it('folders migration has polymorphic parent', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000004_create_folders_table.php');
-        
+
         expect($content)
             ->toContain('$table->morphs(\'parent\');')
             ->toContain("\$table->foreignId('parent_folder_id')->nullable()->constrained('folders')->nullOnDelete();")
@@ -62,7 +62,7 @@ describe('Example Application Migrations', function (): void {
 
     it('documents migration has comprehensive fields', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000005_create_documents_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('documents'")
             ->toContain("\$table->string('title');")
@@ -80,7 +80,7 @@ describe('Example Application Migrations', function (): void {
 
     it('documents migration includes version tracking', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000005_create_documents_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('document_versions'")
             ->toContain("\$table->foreignId('document_id')->constrained()->cascadeOnDelete();")
@@ -93,7 +93,7 @@ describe('Example Application Migrations', function (): void {
 
     it('documents migration includes share tracking', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000005_create_documents_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('document_shares'")
             ->toContain("\$table->foreignId('shared_by')->constrained('users')->restrictOnDelete();")
@@ -104,7 +104,7 @@ describe('Example Application Migrations', function (): void {
 
     it('audit logs migration has proper structure', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/database/migrations/2024_01_01_000006_create_permission_audit_logs_table.php');
-        
+
         expect($content)
             ->toContain("Schema::create('permission_audit_logs'")
             ->toContain("\$table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();")
@@ -121,21 +121,21 @@ describe('Example Application Migrations', function (): void {
 
     it('all migrations have proper indexes', function () use ($examplePath): void {
         $migrations = glob($examplePath . '/database/migrations/*.php');
-        
+
         foreach ($migrations as $migration) {
             $content = file_get_contents($migration);
-            
+
             if (str_contains($migration, 'organizations')) {
                 expect($content)->toContain('$table->index(');
             }
-            
+
             if (str_contains($migration, 'documents')) {
                 expect($content)
                     ->toContain("\$table->index('owner_id');")
                     ->toContain("\$table->index('status');")
                     ->toContain('$table->fullText(');
             }
-            
+
             if (str_contains($migration, 'audit_logs')) {
                 expect($content)
                     ->toContain("\$table->index('user_id');")

--- a/tests/Example/ExampleModelTest.php
+++ b/tests/Example/ExampleModelTest.php
@@ -6,7 +6,7 @@ describe('Example Application Models', function (): void {
 
     it('User model has required traits and methods', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/User.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, Notifiable, HasAuthorization;')
             ->toContain('use OpenFGA\Laravel\Traits\HasAuthorization;')
@@ -20,7 +20,7 @@ describe('Example Application Models', function (): void {
 
     it('Organization model has required relationships', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/Organization.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, HasAuthorization;')
             ->toContain('public function departments()')
@@ -34,7 +34,7 @@ describe('Example Application Models', function (): void {
 
     it('Department model has parent relationship', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/Department.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, HasAuthorization;')
             ->toContain('public function organization()')
@@ -47,7 +47,7 @@ describe('Example Application Models', function (): void {
 
     it('Team model has department relationship', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/Team.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, HasAuthorization;')
             ->toContain('public function department()')
@@ -62,7 +62,7 @@ describe('Example Application Models', function (): void {
 
     it('Document model has authorization methods', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/Document.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, HasAuthorization')
             ->toContain('public function owner()')
@@ -78,7 +78,7 @@ describe('Example Application Models', function (): void {
 
     it('Folder model has parent relationships', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Models/Folder.php');
-        
+
         expect($content)
             ->toContain('use HasFactory, HasAuthorization;')
             ->toContain('public function organization()')
@@ -98,16 +98,16 @@ describe('Example Application Models', function (): void {
             'Department',
             'Team',
             'Document',
-            'Folder'
+            'Folder',
         ];
-        
+
         foreach ($models as $model) {
             $content = file_get_contents($examplePath . "/app/Models/{$model}.php");
-            
+
             expect($content)
                 ->toContain('protected $fillable = [');
-            
-            if ($model === 'Document') {
+
+            if ('Document' === $model) {
                 expect($content)
                     ->toContain("'title'")
                     ->toContain("'content'");
@@ -121,17 +121,17 @@ describe('Example Application Models', function (): void {
     it('models use proper authorization object naming', function () use ($examplePath): void {
         $models = [
             'Organization' => 'organization',
-            'Department' => 'department', 
+            'Department' => 'department',
             'Team' => 'team',
             'Document' => 'document',
-            'Folder' => 'folder'
+            'Folder' => 'folder',
         ];
-        
+
         foreach ($models as $model => $object) {
             $content = file_get_contents($examplePath . "/app/Models/{$model}.php");
-            
+
             expect($content)
-                ->toContain("public function authorizationObject(): string")
+                ->toContain('public function authorizationObject(): string')
                 ->toContain("return '{$object}:' . \$this->id;");
         }
     });

--- a/tests/Example/ExampleRequestTest.php
+++ b/tests/Example/ExampleRequestTest.php
@@ -6,7 +6,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('StoreDocumentRequest has authorization checks', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/StoreDocumentRequest.php');
-        
+
         expect($content)
             ->toContain('class StoreDocumentRequest extends FormRequest')
             ->toContain('public function authorize(): bool')
@@ -22,7 +22,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('StoreDocumentRequest has proper validation rules', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/StoreDocumentRequest.php');
-        
+
         expect($content)
             ->toContain("'title' => 'required|string|max:255'")
             ->toContain("'content' => 'required|string'")
@@ -37,7 +37,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('UpdateDocumentRequest checks editor permissions', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/UpdateDocumentRequest.php');
-        
+
         expect($content)
             ->toContain('class UpdateDocumentRequest extends FormRequest')
             ->toContain('public function authorize(): bool')
@@ -49,7 +49,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('UpdateDocumentRequest has version tracking', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/UpdateDocumentRequest.php');
-        
+
         expect($content)
             ->toContain('protected function prepareForValidation(): void')
             ->toContain('if ($this->has(\'content\'))')
@@ -60,7 +60,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('UpdateDocumentRequest validates publish permission', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/UpdateDocumentRequest.php');
-        
+
         expect($content)
             ->toContain('public function withValidator($validator): void')
             ->toContain("if (\$this->has('status') && \$this->status === 'published')")
@@ -73,12 +73,12 @@ describe('Example Application Request Classes', function (): void {
     it('request classes have custom error messages', function () use ($examplePath): void {
         $storeContent = file_get_contents($examplePath . '/app/Http/Requests/StoreDocumentRequest.php');
         $updateContent = file_get_contents($examplePath . '/app/Http/Requests/UpdateDocumentRequest.php');
-        
+
         expect($storeContent)
             ->toContain('public function messages(): array')
             ->toContain("'title.required' => 'Please provide a title for the document.'")
             ->toContain("'content.required' => 'Document content cannot be empty.'");
-        
+
         expect($updateContent)
             ->toContain('public function messages(): array')
             ->toContain("'title.required' => 'Document title cannot be empty.'")
@@ -87,7 +87,7 @@ describe('Example Application Request Classes', function (): void {
 
     it('StoreDocumentRequest handles tag preparation', function () use ($examplePath): void {
         $content = file_get_contents($examplePath . '/app/Http/Requests/StoreDocumentRequest.php');
-        
+
         expect($content)
             ->toContain('protected function prepareForValidation(): void')
             ->toContain("if (!\$this->has('status'))")

--- a/tests/Example/ExampleStructureTest.php
+++ b/tests/Example/ExampleStructureTest.php
@@ -35,13 +35,13 @@ describe('Example Application Structure', function (): void {
     it('has executable scripts with correct permissions', function () use ($examplePath): void {
         expect($examplePath . '/install.sh')->toBeFile()
             ->and($examplePath . '/docker-setup.sh')->toBeFile();
-        
+
         // Check if files are executable
         $installPerms = fileperms($examplePath . '/install.sh');
         $dockerPerms = fileperms($examplePath . '/docker-setup.sh');
-        
-        expect($installPerms & 0111)->toBeGreaterThan(0)
-            ->and($dockerPerms & 0111)->toBeGreaterThan(0);
+
+        expect($installPerms & 0o111)->toBeGreaterThan(0)
+            ->and($dockerPerms & 0o111)->toBeGreaterThan(0);
     });
 
     it('has all required controllers', function () use ($examplePath): void {
@@ -70,27 +70,32 @@ describe('Example Application Structure', function (): void {
     it('has all required migrations', function () use ($examplePath): void {
         $migrationsPath = $examplePath . '/database/migrations';
         $migrations = glob($migrationsPath . '/*.php');
-        
+
         expect($migrations)->toHaveCount(6);
-        
-        $migrationNames = array_map(fn($path) => basename($path), $migrations);
-        
+
+        $migrationNames = array_map(fn ($path) => basename($path), $migrations);
+
         $hasOrganizations = false;
         $hasDepartments = false;
         $hasTeams = false;
         $hasFolders = false;
         $hasDocuments = false;
         $hasAuditLogs = false;
-        
+
         foreach ($migrationNames as $name) {
             if (str_contains($name, 'create_organizations_table')) $hasOrganizations = true;
+
             if (str_contains($name, 'create_departments_table')) $hasDepartments = true;
+
             if (str_contains($name, 'create_teams_table')) $hasTeams = true;
+
             if (str_contains($name, 'create_folders_table')) $hasFolders = true;
+
             if (str_contains($name, 'create_documents_table')) $hasDocuments = true;
+
             if (str_contains($name, 'create_permission_audit_logs_table')) $hasAuditLogs = true;
         }
-        
+
         expect($hasOrganizations)->toBeTrue()
             ->and($hasDepartments)->toBeTrue()
             ->and($hasTeams)->toBeTrue()

--- a/tests/Example/Pest.php
+++ b/tests/Example/Pest.php
@@ -16,9 +16,8 @@ declare(strict_types=1);
 // Ensure we're testing from the correct directory
 uses()->beforeEach(function (): void {
     $examplePath = __DIR__ . '/../../example';
-    
-    if (!is_dir($examplePath)) {
+
+    if (! is_dir($examplePath)) {
         $this->markTestSkipped('Example directory not found. Please ensure the example application exists at: ' . $examplePath);
     }
 })->in(__DIR__);
-


### PR DESCRIPTION
This pull request focuses on improving code consistency and readability across multiple test files in the project. The changes include adjustments to coding style, logical comparisons, array formatting, and file permissions. These updates aim to standardize the codebase and enhance maintainability.

### Code consistency improvements:

* [`tests/Example/ExampleCodeQualityTest.php`](diffhunk://#diff-9b20b6135a855e90a61cdd7de7d3c2cc7133175dc65ce9a90d782cf5dec3dcd5L38-R38): Adjusted logical comparison syntax in `if` statements to use Yoda conditions for consistency.  
* [`tests/Example/ExampleModelTest.php`](diffhunk://#diff-3180ef5bf6f3aaede86d621983dfa8ca011c5b7da688212a66434162f6cf4ca0L110-R110): Updated `if` conditions to use Yoda style comparisons for improved readability.  

### Formatting adjustments:

* `tests/Example/ExampleCodeQualityTest.php` and `tests/Example/ExampleModelTest.php`: Added trailing commas in arrays to align with modern PHP standards [[1]](diffhunk://#diff-9b20b6135a855e90a61cdd7de7d3c2cc7133175dc65ce9a90d782cf5dec3dcd5L136-R136) [[2]](diffhunk://#diff-3180ef5bf6f3aaede86d621983dfa8ca011c5b7da688212a66434162f6cf4ca0L101-R101) [[3]](diffhunk://#diff-3180ef5bf6f3aaede86d621983dfa8ca011c5b7da688212a66434162f6cf4ca0L127-R134).  
* [`tests/Example/ExampleModelTest.php`](diffhunk://#diff-3180ef5bf6f3aaede86d621983dfa8ca011c5b7da688212a66434162f6cf4ca0L127-R134): Standardized string quotation styles in method expectations for consistency.  

### File permissions and structural changes:

* [`tests/Example/ExampleStructureTest.php`](diffhunk://#diff-026aa1206b4459f52218e5ee08361e6c5875fdd843e21bb3455e7b3f2c892bb5L43-R44): Updated octal notation for file permissions to use `0o` prefix for clarity and compliance with PHP standards.  
* [`tests/Example/ExampleStructureTest.php`](diffhunk://#diff-026aa1206b4459f52218e5ee08361e6c5875fdd843e21bb3455e7b3f2c892bb5R87-R95): Added spacing between conditional checks in migration name validation for better readability.  

### Minor cleanup:

* [`tests/Example/Pest.php`](diffhunk://#diff-ef4a7948e7988b3e0e6550f7c8a4c674de8a1ec43d1a49e4a0c3cc9b81ec76d5L24): Removed unnecessary trailing newline at the end of the file for cleanliness.