### PR TITLE
Delete `replicated` event and fix test suite

### DIFF
--- a/src/Testing/FakeOpenFga.php
+++ b/src/Testing/FakeOpenFga.php
@@ -551,11 +551,10 @@ final class FakeOpenFga
      * @param string $user
      * @param string $relation
      * @param string $object
-     * @return bool
      */
     public function revoke(string $user, string $relation, string $object): bool
     {
-        $this->tuples = array_filter($this->tuples, static fn ($tuple): bool => ! ($tuple['user'] === $user && $tuple['relation'] === $relation && $tuple['object'] === $object));
+        $this->tuples = array_filter($this->tuples, static fn (array $tuple): bool => ! ($tuple['user'] === $user && $tuple['relation'] === $relation && $tuple['object'] === $object));
 
         return true;
     }
@@ -627,7 +626,7 @@ final class FakeOpenFga
 
         // Apply deletes
         foreach ($deletes as $delete) {
-            $this->tuples = array_filter($this->tuples, static fn ($tuple): bool => ! ($tuple['user'] === $delete['user']
+            $this->tuples = array_filter($this->tuples, static fn (array $tuple): bool => ! ($tuple['user'] === $delete['user']
                     && $tuple['relation'] === $delete['relation']
                     && $tuple['object'] === $delete['object']));
         }

--- a/src/Testing/FakeOpenFga.php
+++ b/src/Testing/FakeOpenFga.php
@@ -398,10 +398,13 @@ final class FakeOpenFga
      * @param string $user
      * @param string $relation
      * @param string $object
+     * @return bool
      */
-    public function grant(string $user, string $relation, string $object): void
+    public function grant(string $user, string $relation, string $object): bool
     {
         $this->tuples[] = ['user' => $user, 'relation' => $relation, 'object' => $object];
+
+        return true;
     }
 
     /**
@@ -548,10 +551,13 @@ final class FakeOpenFga
      * @param string $user
      * @param string $relation
      * @param string $object
+     * @return bool
      */
-    public function revoke(string $user, string $relation, string $object): void
+    public function revoke(string $user, string $relation, string $object): bool
     {
         $this->tuples = array_filter($this->tuples, static fn ($tuple): bool => ! ($tuple['user'] === $user && $tuple['relation'] === $relation && $tuple['object'] === $object));
+
+        return true;
     }
 
     /**

--- a/src/Testing/FakesOpenFga.php
+++ b/src/Testing/FakesOpenFga.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenFGA\Laravel\Testing;
 
+use OpenFGA\Laravel\Contracts\ManagerInterface;
 use OpenFGA\Laravel\OpenFgaManager;
+use OpenFGA\Models\Collections\TupleKeysInterface;
 
 /**
  * Trait for faking OpenFGA in tests.
@@ -119,7 +121,7 @@ trait FakesOpenFga // @phpstan-ignore trait.unused
         $this->fakeOpenFga = new FakeOpenFga;
 
         // Create a wrapper manager that delegates to our fake
-        $fakeManager = new readonly class($this->fakeOpenFga) {
+        $fakeManager = new readonly class($this->fakeOpenFga) implements ManagerInterface {
             public function __construct(private FakeOpenFga $fake)
             {
             }
@@ -129,14 +131,14 @@ trait FakesOpenFga // @phpstan-ignore trait.unused
                 return $this->fake->check($user, $relation, $object);
             }
 
-            public function grant(string $user, string $relation, string $object, ?string $connection = null): void
+            public function grant(string|array $user, string $relation, string $object, ?string $connection = null): bool
             {
-                $this->fake->grant($user, $relation, $object);
+                return $this->fake->grant($user, $relation, $object);
             }
 
-            public function revoke(string $user, string $relation, string $object, ?string $connection = null): void
+            public function revoke(string|array $user, string $relation, string $object, ?string $connection = null): bool
             {
-                $this->fake->revoke($user, $relation, $object);
+                return $this->fake->revoke($user, $relation, $object);
             }
 
             public function listObjects(string $user, string $relation, string $type, array $contextualTuples = [], array $context = [], ?string $connection = null): array
@@ -208,6 +210,16 @@ trait FakesOpenFga // @phpstan-ignore trait.unused
                         return $this->fake->check($this->user, $this->relation, $this->object);
                     }
                 };
+            }
+
+            public function listRelations(string $user, string $object, array $relations = [], array $contextualTuples = [], array $context = [], ?string $connection = null,): array
+            {
+                // TODO: Implement listRelations() method.
+            }
+
+            public function write(?TupleKeysInterface $writes = null, ?TupleKeysInterface $deletes = null, ?string $connection = null,): bool
+            {
+                // TODO: Implement write() method.
             }
         };
 

--- a/src/Testing/FakesOpenFga.php
+++ b/src/Testing/FakesOpenFga.php
@@ -214,12 +214,12 @@ trait FakesOpenFga // @phpstan-ignore trait.unused
 
             public function listRelations(string $user, string $object, array $relations = [], array $contextualTuples = [], array $context = [], ?string $connection = null,): array
             {
-                // TODO: Implement listRelations() method.
+                throw new \RuntimeException('listRelations() is not yet implemented in the fake.');
             }
 
             public function write(?TupleKeysInterface $writes = null, ?TupleKeysInterface $deletes = null, ?string $connection = null,): bool
             {
-                // TODO: Implement write() method.
+                throw new \RuntimeException('write() is not yet implemented in the fake.');
             }
         };
 

--- a/src/Traits/HasAuthorization.php
+++ b/src/Traits/HasAuthorization.php
@@ -210,13 +210,6 @@ trait HasAuthorization
                 $model->revokeAllPermissions();
             }
         });
-
-        // Add model event to replicate permissions on duplication
-        static::replicated(function (Model $original, Model $replica): void {
-            if ($this->shouldReplicatePermissions()) {
-                $original->replicatePermissionsTo($replica);
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## Summary

Delete `replicated` event and fix test suite

Fixes #35

## Type

- [x] Bug fix (non-breaking)  
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test improvement
- [ ] Performance improvement

## Implementation

Deleted `replicated` event this it doesnt exist in default laravel framework
Fixed types and implemented fake inline class

I didn't applied missed contract methods in this PR

## Testing

<!-- How did you verify your changes? -->

## Checklist

- [x] Passing static analysis (PHPStan/Psalm)
- [x] Documentation updated (if needed)
- [x] Follows [PSR-12](https://www.php-fig.org/psr/psr-12/) coding standards
- [x] Commit messages follow conventional commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grant and revoke operations now return a success boolean.
  * Added new public methods for listing relations and applying batch authorization writes (placeholders for pending implementation).

* **Behavior Changes**
  * Permissions are no longer automatically copied when a model is duplicated; duplicates will not inherit original permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->